### PR TITLE
Add .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,18 @@ before_script:
 make_test:
   script:
     - make test
+  tags:
+    - linux
 
 make_examples:
   script:
     - make -C $HOME/local/share/doc/sharness/examples
+  tags:
+    - linux
+
+windows_make_test:
+  before_script:
+  script:
+    - make test
+  tags:
+    - windows

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+before_script:
+  - apt-get update -qq && apt-get install -y -qq libio-pty-perl
+  - TEST_OPTS=-v
+  - export TEST_OPTS
+  - DEFAULT_TEST_TARGET=prove
+  - export DEFAULT_TEST_TARGET
+  - make install prefix=$HOME/local
+
+make_test:
+  script:
+    - make test
+
+make_examples:
+  script:
+    - make -C $HOME/local/share/doc/sharness/examples


### PR DESCRIPTION
This is to add GitLab CI support for testing sharness.

The good thing with GitLab CI support is that we could test on many platforms like Windows and MacOS as well as on Linux.

There is already a mirror on GitLab: https://gitlab.com/chriscool/sharness
And this script has been tested there: https://gitlab.com/chriscool/sharness/pipelines/4349136

I need to see if I can add runners to test on MacOS and Windows.
