### PR TITLE
Fix test_seq arithmetic expression quoting

### DIFF
--- a/lib-sharness/functions.sh
+++ b/lib-sharness/functions.sh
@@ -425,7 +425,7 @@ test_seq() {
 	while test "$i" -le "$j"
 	do
 		echo "$i" || return
-		i=$(("$i" + 1))
+		i=$((i + 1))
 	done
 }
 


### PR DESCRIPTION
`test_seq()` uses double-quotes to protect the variable within its arithmetic expression; however, double-quotes inside such an expression are not treated specially.

Remove the double-quotes since they cause errors with some shells.  For example:
- Current versions of `dash`
```arithmetic expression: expecting primary: ""1" + 1"```
- OpenBSD 7.2 `sh`
```"1" + 1: unexpected `"'```
- Ubuntu 16.04 `bash-4.3.48`
```"1" + 1: syntax error: operand expected (error token is ""1" + 1")```

Also, remove the '$' character for variable expansion since tokens within an arithmetic expression undergo variable expansion, and this matches the coding style used in the rest of the file.