### PR TITLE
Makefile: Allow prefix to be set from outside

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-prefix = $(HOME)
+prefix ?= $(HOME)
 
 INSTALL_DIR = $(prefix)/share/sharness
 DOC_DIR = $(prefix)/share/doc/sharness


### PR DESCRIPTION
This way external build systems can override prefix and decide to not install into $HOME.


Fixes: c11923ae2537 ("make: add install and uninstall targets")