### PR TITLE
fix readme with right url for cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ documentation.
 
 First, clone the Git repository:
 
-    $ git clone git://github.com/felipec/sharness.git
+    $ git clone git@github.com:felipec/sharness.git
 
 Then choose an installation method that works best for you:
 


### PR DESCRIPTION
update the url in readme which was `git://github.com/felipec/sharness.git` to  `git@github.com:felipec/sharness.git`