### PR TITLE
Fix zsh parsing error on NetBSD

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -21,7 +21,7 @@
 if test -n "${ZSH_VERSION-}"
 then
 	# shellcheck disable=SC2296
-	SHARNESS_SOURCE=${(%):-%x}
+	eval 'SHARNESS_SOURCE=${(%):-%x}'
 	emulate sh -o POSIX_ARGZERO
 else
 	# shellcheck disable=SC3028


### PR DESCRIPTION
The zsh-specific parameter expansion ${(%):-%x} introduced in commit 96e0ea2c7 causes a parse error on NetBSD where /bin/sh cannot parse this syntax, even though it is inside a zsh-only conditional block.

The error occurs because the shell must parse the entire script before execution, and NetBSD's /bin/sh fails when it encounters the zsh-specific syntax with: "Syntax error: Bad substitution".

Wrap the assignment in eval to defer parsing until runtime, when the script is actually running under zsh.  This maintains the fix for the NO_FUNCTION_ARGZERO option while restoring compatibility with NetBSD's /bin/sh.

Tested on NetBSD 9.4 and 10.1 (without zsh installed) where the parsing error was reproducible and verified the eval wrapper resolves it.  Also tested on other platforms (most without zsh) including multiple Linux distros, FreeBSD, OpenBSD, and macOS which were not affected before or after this fix.